### PR TITLE
feat(keyboard): Add keyboard shortcuts for common actions

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/domain/model/KeyboardShortcut.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/domain/model/KeyboardShortcut.kt
@@ -1,0 +1,24 @@
+package com.manjee.linkops.domain.model
+
+/**
+ * Represents a keyboard shortcut bound to an application action
+ *
+ * @param action The action this shortcut triggers
+ * @param displayKeys Human-readable key combination (e.g., "Ctrl+R")
+ * @param description Explanation of what the shortcut does
+ */
+data class KeyboardShortcut(
+    val action: ShortcutAction,
+    val displayKeys: String,
+    val description: String
+)
+
+/**
+ * Available keyboard shortcut actions
+ */
+enum class ShortcutAction {
+    REFRESH_DEVICES,
+    FOCUS_SEARCH,
+    CLOSE_PANEL,
+    SHOW_SHORTCUTS_HELP
+}

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/component/KeyboardShortcutHandler.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/component/KeyboardShortcutHandler.kt
@@ -1,0 +1,92 @@
+package com.manjee.linkops.ui.component
+
+import androidx.compose.ui.input.key.*
+import com.manjee.linkops.domain.model.KeyboardShortcut
+import com.manjee.linkops.domain.model.ShortcutAction
+
+/**
+ * Handles keyboard events and maps them to shortcut actions
+ *
+ * Supports platform-aware modifier keys (Ctrl on Windows/Linux, Meta/Cmd on macOS).
+ */
+class KeyboardShortcutHandler {
+
+    /**
+     * Determines the shortcut action for a given Compose key event
+     *
+     * @param event The Compose key event to evaluate
+     * @return The matching shortcut action, or null if no shortcut matches
+     */
+    fun handleKeyEvent(event: KeyEvent): ShortcutAction? {
+        if (event.type != KeyEventType.KeyDown) return null
+
+        return resolve(
+            key = event.key,
+            isCtrlPressed = event.isCtrlPressed,
+            isMetaPressed = event.isMetaPressed,
+            isShiftPressed = event.isShiftPressed
+        )
+    }
+
+    /**
+     * Resolves a shortcut action from individual key state parameters
+     *
+     * @param key The key that was pressed
+     * @param isCtrlPressed Whether Ctrl is held
+     * @param isMetaPressed Whether Meta/Cmd is held
+     * @param isShiftPressed Whether Shift is held
+     * @return The matching shortcut action, or null if no shortcut matches
+     */
+    fun resolve(
+        key: Key,
+        isCtrlPressed: Boolean,
+        isMetaPressed: Boolean,
+        isShiftPressed: Boolean
+    ): ShortcutAction? {
+        val hasModifier = isCtrlPressed || isMetaPressed
+
+        return when {
+            hasModifier && key == Key.R -> ShortcutAction.REFRESH_DEVICES
+            hasModifier && key == Key.F -> ShortcutAction.FOCUS_SEARCH
+            key == Key.Escape -> ShortcutAction.CLOSE_PANEL
+            key == Key.Slash && isShiftPressed && !isCtrlPressed && !isMetaPressed -> ShortcutAction.SHOW_SHORTCUTS_HELP
+            else -> null
+        }
+    }
+
+    companion object {
+        private val isMac = System.getProperty("os.name")
+            .lowercase()
+            .contains("mac")
+
+        private val modifierDisplay = if (isMac) "Cmd" else "Ctrl"
+
+        /**
+         * Returns all registered keyboard shortcuts with platform-aware display keys
+         *
+         * @return List of all available keyboard shortcuts
+         */
+        fun allShortcuts(): List<KeyboardShortcut> = listOf(
+            KeyboardShortcut(
+                action = ShortcutAction.REFRESH_DEVICES,
+                displayKeys = "$modifierDisplay+R",
+                description = "Refresh devices"
+            ),
+            KeyboardShortcut(
+                action = ShortcutAction.FOCUS_SEARCH,
+                displayKeys = "$modifierDisplay+F",
+                description = "Focus search field"
+            ),
+            KeyboardShortcut(
+                action = ShortcutAction.CLOSE_PANEL,
+                displayKeys = "Escape",
+                description = "Close side panel"
+            ),
+            KeyboardShortcut(
+                action = ShortcutAction.SHOW_SHORTCUTS_HELP,
+                displayKeys = "?",
+                description = "Show keyboard shortcuts"
+            )
+        )
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/component/ShortcutsHelpDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/component/ShortcutsHelpDialog.kt
@@ -1,0 +1,84 @@
+package com.manjee.linkops.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.manjee.linkops.domain.model.KeyboardShortcut
+
+/**
+ * Dialog that displays all available keyboard shortcuts
+ *
+ * @param shortcuts List of shortcuts to display
+ * @param onDismiss Callback when the dialog is dismissed
+ */
+@Composable
+fun ShortcutsHelpDialog(
+    shortcuts: List<KeyboardShortcut>,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = "Keyboard Shortcuts",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                shortcuts.forEach { shortcut ->
+                    ShortcutRow(shortcut = shortcut)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Close")
+            }
+        }
+    )
+}
+
+/**
+ * A single shortcut row showing the key combination and description
+ */
+@Composable
+private fun ShortcutRow(shortcut: KeyboardShortcut) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = shortcut.description,
+            style = MaterialTheme.typography.bodyMedium
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Box(
+            modifier = Modifier
+                .background(
+                    MaterialTheme.colorScheme.surfaceVariant,
+                    RoundedCornerShape(4.dp)
+                )
+                .padding(horizontal = 8.dp, vertical = 4.dp)
+        ) {
+            Text(
+                text = shortcut.displayKeys,
+                style = MaterialTheme.typography.bodySmall.copy(
+                    fontFamily = FontFamily.Monospace
+                ),
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/screen/diagnostics/DiagnosticsScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/screen/diagnostics/DiagnosticsScreen.kt
@@ -16,10 +16,13 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.manjee.linkops.LocalSearchFocusTrigger
 import com.manjee.linkops.domain.model.*
 import com.manjee.linkops.ui.component.*
 import com.manjee.linkops.ui.theme.LinkOpsColors
@@ -116,12 +119,23 @@ private fun DomainInputSection(
             fontWeight = FontWeight.SemiBold
         )
 
+        val focusRequester = remember { FocusRequester() }
+        val searchFocusTrigger by LocalSearchFocusTrigger.current
+
+        LaunchedEffect(searchFocusTrigger) {
+            if (searchFocusTrigger > 0) {
+                focusRequester.requestFocus()
+            }
+        }
+
         OutlinedTextField(
             value = domain,
             onValueChange = onDomainChange,
             label = { Text("Domain") },
             placeholder = { Text("example.com") },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester),
             singleLine = true,
             leadingIcon = {
                 Icon(Icons.Default.Search, contentDescription = null)

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/screen/main/MainScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/screen/main/MainScreen.kt
@@ -16,8 +16,11 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.manjee.linkops.LocalSearchFocusTrigger
 import com.manjee.linkops.domain.model.IntentConfig
 import com.manjee.linkops.ui.component.*
 import com.manjee.linkops.ui.theme.LinkOpsColors
@@ -440,12 +443,23 @@ private fun FireIntentSection(
             fontWeight = FontWeight.SemiBold
         )
 
+        val focusRequester = remember { FocusRequester() }
+        val searchFocusTrigger by LocalSearchFocusTrigger.current
+
+        LaunchedEffect(searchFocusTrigger) {
+            if (searchFocusTrigger > 0) {
+                focusRequester.requestFocus()
+            }
+        }
+
         OutlinedTextField(
             value = intentUri,
             onValueChange = onIntentUriChange,
             label = { Text("URI") },
             placeholder = { Text("myapp://product/123 or https://example.com/path") },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester),
             singleLine = true,
             enabled = selectedDevice != null
         )

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/screen/manifest/ManifestAnalyzerScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/screen/manifest/ManifestAnalyzerScreen.kt
@@ -19,11 +19,14 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.manjee.linkops.LocalSearchFocusTrigger
 import com.manjee.linkops.domain.model.*
 import com.manjee.linkops.domain.model.IntentConfig
 import com.manjee.linkops.domain.repository.PackageFilter
@@ -268,12 +271,23 @@ private fun PackageSearchSection(
             }
         }
 
+        val focusRequester = remember { FocusRequester() }
+        val searchFocusTrigger by LocalSearchFocusTrigger.current
+
+        LaunchedEffect(searchFocusTrigger) {
+            if (searchFocusTrigger > 0) {
+                focusRequester.requestFocus()
+            }
+        }
+
         OutlinedTextField(
             value = query,
             onValueChange = onQueryChange,
             label = { Text("Search packages") },
             placeholder = { Text("com.example...") },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester),
             singleLine = true,
             enabled = enabled,
             leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },

--- a/composeApp/src/jvmTest/kotlin/com/manjee/linkops/domain/model/KeyboardShortcutTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/manjee/linkops/domain/model/KeyboardShortcutTest.kt
@@ -1,0 +1,67 @@
+package com.manjee.linkops.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class KeyboardShortcutTest {
+
+    @Test
+    fun `KeyboardShortcut data class should support equality`() {
+        val shortcut1 = KeyboardShortcut(
+            action = ShortcutAction.REFRESH_DEVICES,
+            displayKeys = "Ctrl+R",
+            description = "Refresh devices"
+        )
+        val shortcut2 = KeyboardShortcut(
+            action = ShortcutAction.REFRESH_DEVICES,
+            displayKeys = "Ctrl+R",
+            description = "Refresh devices"
+        )
+        assertEquals(shortcut1, shortcut2)
+    }
+
+    @Test
+    fun `KeyboardShortcut data class should differ by action`() {
+        val shortcut1 = KeyboardShortcut(
+            action = ShortcutAction.REFRESH_DEVICES,
+            displayKeys = "Ctrl+R",
+            description = "Refresh devices"
+        )
+        val shortcut2 = KeyboardShortcut(
+            action = ShortcutAction.FOCUS_SEARCH,
+            displayKeys = "Ctrl+R",
+            description = "Refresh devices"
+        )
+        assertNotEquals(shortcut1, shortcut2)
+    }
+
+    @Test
+    fun `KeyboardShortcut copy should work correctly`() {
+        val original = KeyboardShortcut(
+            action = ShortcutAction.REFRESH_DEVICES,
+            displayKeys = "Ctrl+R",
+            description = "Refresh devices"
+        )
+        val copy = original.copy(displayKeys = "Cmd+R")
+        assertEquals(ShortcutAction.REFRESH_DEVICES, copy.action)
+        assertEquals("Cmd+R", copy.displayKeys)
+        assertEquals("Refresh devices", copy.description)
+    }
+
+    @Test
+    fun `ShortcutAction should have four values`() {
+        assertEquals(4, ShortcutAction.entries.size)
+    }
+
+    @Test
+    fun `ShortcutAction should contain all expected values`() {
+        val expectedValues = setOf(
+            ShortcutAction.REFRESH_DEVICES,
+            ShortcutAction.FOCUS_SEARCH,
+            ShortcutAction.CLOSE_PANEL,
+            ShortcutAction.SHOW_SHORTCUTS_HELP
+        )
+        assertEquals(expectedValues, ShortcutAction.entries.toSet())
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/com/manjee/linkops/ui/component/KeyboardShortcutHandlerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/manjee/linkops/ui/component/KeyboardShortcutHandlerTest.kt
@@ -1,0 +1,246 @@
+package com.manjee.linkops.ui.component
+
+import androidx.compose.ui.input.key.Key
+import com.manjee.linkops.domain.model.ShortcutAction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class KeyboardShortcutHandlerTest {
+
+    private val handler = KeyboardShortcutHandler()
+
+    // --- Ctrl+R -> REFRESH_DEVICES ---
+
+    @Test
+    fun `Ctrl+R should return REFRESH_DEVICES`() {
+        val result = handler.resolve(
+            key = Key.R,
+            isCtrlPressed = true,
+            isMetaPressed = false,
+            isShiftPressed = false
+        )
+        assertEquals(ShortcutAction.REFRESH_DEVICES, result)
+    }
+
+    @Test
+    fun `Meta+R should return REFRESH_DEVICES`() {
+        val result = handler.resolve(
+            key = Key.R,
+            isCtrlPressed = false,
+            isMetaPressed = true,
+            isShiftPressed = false
+        )
+        assertEquals(ShortcutAction.REFRESH_DEVICES, result)
+    }
+
+    @Test
+    fun `Ctrl+Meta+R should return REFRESH_DEVICES`() {
+        val result = handler.resolve(
+            key = Key.R,
+            isCtrlPressed = true,
+            isMetaPressed = true,
+            isShiftPressed = false
+        )
+        assertEquals(ShortcutAction.REFRESH_DEVICES, result)
+    }
+
+    // --- Ctrl+F -> FOCUS_SEARCH ---
+
+    @Test
+    fun `Ctrl+F should return FOCUS_SEARCH`() {
+        val result = handler.resolve(
+            key = Key.F,
+            isCtrlPressed = true,
+            isMetaPressed = false,
+            isShiftPressed = false
+        )
+        assertEquals(ShortcutAction.FOCUS_SEARCH, result)
+    }
+
+    @Test
+    fun `Meta+F should return FOCUS_SEARCH`() {
+        val result = handler.resolve(
+            key = Key.F,
+            isCtrlPressed = false,
+            isMetaPressed = true,
+            isShiftPressed = false
+        )
+        assertEquals(ShortcutAction.FOCUS_SEARCH, result)
+    }
+
+    // --- Escape -> CLOSE_PANEL ---
+
+    @Test
+    fun `Escape should return CLOSE_PANEL`() {
+        val result = handler.resolve(
+            key = Key.Escape,
+            isCtrlPressed = false,
+            isMetaPressed = false,
+            isShiftPressed = false
+        )
+        assertEquals(ShortcutAction.CLOSE_PANEL, result)
+    }
+
+    @Test
+    fun `Escape with Ctrl should still return CLOSE_PANEL`() {
+        val result = handler.resolve(
+            key = Key.Escape,
+            isCtrlPressed = true,
+            isMetaPressed = false,
+            isShiftPressed = false
+        )
+        assertEquals(ShortcutAction.CLOSE_PANEL, result)
+    }
+
+    // --- Shift+/ (?) -> SHOW_SHORTCUTS_HELP ---
+
+    @Test
+    fun `Shift+Slash should return SHOW_SHORTCUTS_HELP`() {
+        val result = handler.resolve(
+            key = Key.Slash,
+            isCtrlPressed = false,
+            isMetaPressed = false,
+            isShiftPressed = true
+        )
+        assertEquals(ShortcutAction.SHOW_SHORTCUTS_HELP, result)
+    }
+
+    // --- Unbound keys should return null ---
+
+    @Test
+    fun `plain letter key should return null`() {
+        val result = handler.resolve(
+            key = Key.A,
+            isCtrlPressed = false,
+            isMetaPressed = false,
+            isShiftPressed = false
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `R without modifier should return null`() {
+        val result = handler.resolve(
+            key = Key.R,
+            isCtrlPressed = false,
+            isMetaPressed = false,
+            isShiftPressed = false
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `F without modifier should return null`() {
+        val result = handler.resolve(
+            key = Key.F,
+            isCtrlPressed = false,
+            isMetaPressed = false,
+            isShiftPressed = false
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `Slash without Shift should return null`() {
+        val result = handler.resolve(
+            key = Key.Slash,
+            isCtrlPressed = false,
+            isMetaPressed = false,
+            isShiftPressed = false
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `Ctrl+Shift+Slash should return null`() {
+        val result = handler.resolve(
+            key = Key.Slash,
+            isCtrlPressed = true,
+            isMetaPressed = false,
+            isShiftPressed = true
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `Meta+Shift+Slash should return null`() {
+        val result = handler.resolve(
+            key = Key.Slash,
+            isCtrlPressed = false,
+            isMetaPressed = true,
+            isShiftPressed = true
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `Ctrl+A should return null`() {
+        val result = handler.resolve(
+            key = Key.A,
+            isCtrlPressed = true,
+            isMetaPressed = false,
+            isShiftPressed = false
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `Space key should return null`() {
+        val result = handler.resolve(
+            key = Key.Spacebar,
+            isCtrlPressed = false,
+            isMetaPressed = false,
+            isShiftPressed = false
+        )
+        assertNull(result)
+    }
+
+    // --- allShortcuts() ---
+
+    @Test
+    fun `allShortcuts should return all four shortcuts`() {
+        val shortcuts = KeyboardShortcutHandler.allShortcuts()
+        assertEquals(4, shortcuts.size)
+    }
+
+    @Test
+    fun `allShortcuts should cover all ShortcutAction values`() {
+        val shortcuts = KeyboardShortcutHandler.allShortcuts()
+        val actions = shortcuts.map { it.action }.toSet()
+        assertEquals(ShortcutAction.entries.toSet(), actions)
+    }
+
+    @Test
+    fun `allShortcuts descriptions should not be blank`() {
+        val shortcuts = KeyboardShortcutHandler.allShortcuts()
+        shortcuts.forEach { shortcut ->
+            assertNotNull(shortcut.description)
+            assert(shortcut.description.isNotBlank()) {
+                "Description should not be blank for ${shortcut.action}"
+            }
+        }
+    }
+
+    @Test
+    fun `allShortcuts display keys should not be blank`() {
+        val shortcuts = KeyboardShortcutHandler.allShortcuts()
+        shortcuts.forEach { shortcut ->
+            assert(shortcut.displayKeys.isNotBlank()) {
+                "Display keys should not be blank for ${shortcut.action}"
+            }
+        }
+    }
+
+    @Test
+    fun `allShortcuts display keys should use Cmd or Ctrl prefix`() {
+        val shortcuts = KeyboardShortcutHandler.allShortcuts()
+        val modifiedShortcuts = shortcuts.filter { it.displayKeys.contains("+") }
+        modifiedShortcuts.forEach { shortcut ->
+            assert(shortcut.displayKeys.startsWith("Cmd") || shortcut.displayKeys.startsWith("Ctrl")) {
+                "Modified shortcut should start with Cmd or Ctrl: ${shortcut.displayKeys}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add global keyboard shortcuts: `Ctrl/Cmd+R` (refresh devices), `Ctrl/Cmd+F` (focus search field), `Escape` (navigate back), `?` (show shortcuts help dialog)
- Each screen wires its primary search/input field to respond to the focus shortcut via a `LocalSearchFocusTrigger` CompositionLocal
- Includes `ShortcutsHelpDialog` with platform-aware key labels (Cmd on macOS, Ctrl on others)

## Files Changed

### New Files
| File | Layer | Purpose |
|------|-------|---------|
| `domain/model/KeyboardShortcut.kt` | Domain | Data model for shortcuts + `ShortcutAction` enum |
| `ui/component/KeyboardShortcutHandler.kt` | UI | Maps key events to shortcut actions |
| `ui/component/ShortcutsHelpDialog.kt` | UI | Dialog listing all available shortcuts |
| `jvmTest/.../KeyboardShortcutHandlerTest.kt` | Test | 21 tests for key resolution logic |
| `jvmTest/.../KeyboardShortcutTest.kt` | Test | 5 tests for domain model |

### Modified Files
| File | Change |
|------|--------|
| `App.kt` | Added `onPreviewKeyEvent` handler, `LocalSearchFocusTrigger`, shortcuts dialog |
| `MainScreen.kt` | Wired URI field to focus trigger |
| `DiagnosticsScreen.kt` | Wired domain field to focus trigger |
| `ManifestAnalyzerScreen.kt` | Wired package search field to focus trigger |

## Test plan
- [x] All 26 new tests pass (21 handler + 5 model)
- [x] Full `./gradlew :composeApp:jvmTest` passes
- [x] `./gradlew :composeApp:compileKotlinJvm` compiles without errors
- [x] Manual: Press `Ctrl/Cmd+R` on Dashboard to verify device refresh
- [x] Manual: Press `Ctrl/Cmd+F` to verify search field focus per screen
- [x] Manual: Press `Escape` to verify back navigation
- [x] Manual: Press `?` to verify shortcuts help dialog appears

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)