### PR TITLE
feat(diagnostics): Add Verification Deep Dive - Status Tracking & Fingerprint Comparison

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/App.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/App.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.VerifiedUser
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -18,6 +19,8 @@ import com.manjee.linkops.ui.component.ShortcutsHelpDialog
 import com.manjee.linkops.ui.navigation.*
 import com.manjee.linkops.ui.screen.diagnostics.DiagnosticsScreen
 import com.manjee.linkops.ui.screen.diagnostics.DiagnosticsViewModel
+import com.manjee.linkops.ui.screen.diagnostics.VerificationDeepDiveScreen
+import com.manjee.linkops.ui.screen.diagnostics.VerificationDeepDiveViewModel
 import com.manjee.linkops.ui.screen.main.MainScreen
 import com.manjee.linkops.ui.screen.main.MainViewModel
 import com.manjee.linkops.ui.screen.manifest.ManifestAnalyzerScreen
@@ -48,6 +51,7 @@ fun App() {
     val mainViewModel = remember { MainViewModel() }
     val diagnosticsViewModel = remember { DiagnosticsViewModel() }
     val manifestAnalyzerViewModel = remember { ManifestAnalyzerViewModel() }
+    val verificationDeepDiveViewModel = remember { VerificationDeepDiveViewModel() }
     val keyboardShortcutHandler = remember { KeyboardShortcutHandler() }
     val searchFocusTrigger = remember { mutableStateOf(0) }
 
@@ -59,6 +63,7 @@ fun App() {
             mainViewModel.onCleared()
             diagnosticsViewModel.onCleared()
             manifestAnalyzerViewModel.onCleared()
+            verificationDeepDiveViewModel.onCleared()
         }
     }
 
@@ -128,6 +133,14 @@ fun App() {
                                 )
                             }
 
+                            Screen.VerificationDeepDive -> {
+                                val mainUiState by mainViewModel.uiState.collectAsState()
+                                VerificationDeepDiveScreen(
+                                    viewModel = verificationDeepDiveViewModel,
+                                    devices = mainUiState.devices
+                                )
+                            }
+
                             Screen.Settings -> {
                                 // TODO: Implement SettingsScreen
                                 MainScreen(viewModel = mainViewModel)
@@ -180,6 +193,13 @@ private fun NavigationSidebar(
             label = { Text("Diagnostics") },
             selected = currentScreen == Screen.Diagnostics,
             onClick = { onNavigate(Screen.Diagnostics) }
+        )
+
+        NavigationRailItem(
+            icon = { Icon(Icons.Default.VerifiedUser, contentDescription = "Deep Dive") },
+            label = { Text("Deep Dive") },
+            selected = currentScreen == Screen.VerificationDeepDive,
+            onClick = { onNavigate(Screen.VerificationDeepDive) }
         )
 
         NavigationRailItem(

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/data/analyzer/CertificateFingerprintComparator.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/data/analyzer/CertificateFingerprintComparator.kt
@@ -1,0 +1,63 @@
+package com.manjee.linkops.data.analyzer
+
+import com.manjee.linkops.domain.model.AssetLinksContent
+import com.manjee.linkops.domain.model.FingerprintComparisonResult
+
+/**
+ * Compares local APK certificate fingerprints against remote assetlinks.json fingerprints
+ */
+class CertificateFingerprintComparator {
+
+    /**
+     * Compare a local fingerprint against fingerprints in assetlinks.json content
+     *
+     * @param localFingerprint SHA256 fingerprint from the device (may be null)
+     * @param packageName Package name to look up in assetlinks.json
+     * @param assetLinksContent Parsed assetlinks.json content (may be null if fetch failed)
+     * @return Comparison result
+     */
+    fun compare(
+        localFingerprint: String?,
+        packageName: String,
+        assetLinksContent: AssetLinksContent?
+    ): FingerprintComparisonResult {
+        if (localFingerprint == null) {
+            return FingerprintComparisonResult.NoLocalFingerprint
+        }
+
+        if (assetLinksContent == null) {
+            return FingerprintComparisonResult.RemoteUnavailable
+        }
+
+        val remoteFingerprints = assetLinksContent.getFingerprintsForPackage(packageName)
+        if (remoteFingerprints.isEmpty()) {
+            return FingerprintComparisonResult.NoRemoteFingerprint
+        }
+
+        val normalizedLocal = normalizeFingerprint(localFingerprint)
+        val match = remoteFingerprints.any { remote ->
+            normalizeFingerprint(remote) == normalizedLocal
+        }
+
+        return if (match) {
+            FingerprintComparisonResult.Match
+        } else {
+            FingerprintComparisonResult.Mismatch(
+                localFingerprint = localFingerprint,
+                remoteFingerprints = remoteFingerprints
+            )
+        }
+    }
+
+    companion object {
+        /**
+         * Normalize a fingerprint for comparison by removing colons and converting to uppercase
+         *
+         * @param fingerprint Raw fingerprint string
+         * @return Normalized fingerprint
+         */
+        fun normalizeFingerprint(fingerprint: String): String {
+            return fingerprint.uppercase().replace(":", "")
+        }
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/data/analyzer/VerificationFailureAnalyzer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/data/analyzer/VerificationFailureAnalyzer.kt
@@ -1,0 +1,124 @@
+package com.manjee.linkops.data.analyzer
+
+import com.manjee.linkops.domain.model.*
+
+/**
+ * Analyzes verification failures and provides root cause identification with actionable suggestions
+ */
+class VerificationFailureAnalyzer {
+
+    /**
+     * Analyze a domain's verification result and identify failure reasons
+     *
+     * @param verificationState Device-reported verification state
+     * @param fingerprintResult Result of fingerprint comparison
+     * @param assetLinksStatus Status of the assetlinks.json fetch
+     * @param packageName The package name being analyzed
+     * @param domain The domain being analyzed
+     * @return Pair of failure reasons and suggestions
+     */
+    fun analyze(
+        verificationState: VerificationState,
+        fingerprintResult: FingerprintComparisonResult,
+        assetLinksStatus: AssetLinksStatus,
+        packageName: String,
+        domain: String
+    ): Pair<List<FailureReason>, List<String>> {
+        // If verification is successful, no failures to report
+        if (verificationState.isSuccessful) {
+            return emptyList<FailureReason>() to emptyList()
+        }
+
+        val reasons = mutableListOf<FailureReason>()
+        val suggestions = mutableListOf<String>()
+
+        // Check assetlinks.json availability
+        analyzeAssetLinksStatus(assetLinksStatus, domain, reasons, suggestions)
+
+        // Check fingerprint match
+        analyzeFingerprintResult(fingerprintResult, packageName, domain, reasons, suggestions)
+
+        // If no specific reason found, mark as unknown
+        if (reasons.isEmpty()) {
+            reasons.add(FailureReason.UNKNOWN)
+            suggestions.add(
+                "Verification failed for unknown reason. " +
+                    "Try running 'adb shell pm verify-app-links --re-verify $packageName' " +
+                    "and check logcat for details."
+            )
+        }
+
+        return reasons to suggestions
+    }
+
+    private fun analyzeAssetLinksStatus(
+        status: AssetLinksStatus,
+        domain: String,
+        reasons: MutableList<FailureReason>,
+        suggestions: MutableList<String>
+    ) {
+        when (status) {
+            AssetLinksStatus.NOT_FOUND -> {
+                reasons.add(FailureReason.ASSET_LINKS_MISSING)
+                suggestions.add(
+                    "Create assetlinks.json at https://$domain/.well-known/assetlinks.json " +
+                        "with the correct package name and SHA256 fingerprint."
+                )
+            }
+            AssetLinksStatus.INVALID_JSON -> {
+                reasons.add(FailureReason.ASSET_LINKS_INVALID_JSON)
+                suggestions.add(
+                    "Fix the JSON syntax in https://$domain/.well-known/assetlinks.json. " +
+                        "Use the Digital Asset Links validator to check the format."
+                )
+            }
+            AssetLinksStatus.NETWORK_ERROR -> {
+                reasons.add(FailureReason.ASSET_LINKS_NETWORK_ERROR)
+                suggestions.add(
+                    "Check that $domain is reachable and the server responds to HTTPS requests. " +
+                        "Ensure the SSL certificate is valid."
+                )
+            }
+            AssetLinksStatus.REDIRECT -> {
+                reasons.add(FailureReason.ASSET_LINKS_REDIRECT)
+                suggestions.add(
+                    "The assetlinks.json at $domain is served via redirect, which is not allowed. " +
+                        "Serve the file directly at https://$domain/.well-known/assetlinks.json " +
+                        "without any redirects."
+                )
+            }
+            AssetLinksStatus.VALID, AssetLinksStatus.NOT_CHECKED -> { /* no issue */ }
+        }
+    }
+
+    private fun analyzeFingerprintResult(
+        result: FingerprintComparisonResult,
+        packageName: String,
+        domain: String,
+        reasons: MutableList<FailureReason>,
+        suggestions: MutableList<String>
+    ) {
+        when (result) {
+            is FingerprintComparisonResult.Mismatch -> {
+                reasons.add(FailureReason.FINGERPRINT_MISMATCH)
+                suggestions.add(
+                    "Certificate fingerprint mismatch. " +
+                        "Update the sha256_cert_fingerprints in " +
+                        "https://$domain/.well-known/assetlinks.json " +
+                        "to match the APK signing certificate: ${result.localFingerprint}"
+                )
+            }
+            is FingerprintComparisonResult.NoRemoteFingerprint -> {
+                reasons.add(FailureReason.PACKAGE_NOT_IN_ASSET_LINKS)
+                suggestions.add(
+                    "Package $packageName is not declared in " +
+                        "https://$domain/.well-known/assetlinks.json. " +
+                        "Add a statement with the correct package name and fingerprint."
+                )
+            }
+            is FingerprintComparisonResult.Match,
+            is FingerprintComparisonResult.NoLocalFingerprint,
+            is FingerprintComparisonResult.RemoteUnavailable -> { /* no additional issue */ }
+        }
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/data/repository/VerificationDiagnosticsRepositoryImpl.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/data/repository/VerificationDiagnosticsRepositoryImpl.kt
@@ -1,0 +1,143 @@
+package com.manjee.linkops.data.repository
+
+import com.manjee.linkops.data.analyzer.CertificateFingerprintComparator
+import com.manjee.linkops.data.analyzer.VerificationFailureAnalyzer
+import com.manjee.linkops.data.parser.DumpsysParser
+import com.manjee.linkops.data.parser.GetAppLinksParser
+import com.manjee.linkops.data.strategy.AdbCommandStrategyFactory
+import com.manjee.linkops.domain.model.*
+import com.manjee.linkops.domain.repository.AssetLinksRepository
+import com.manjee.linkops.domain.repository.VerificationDiagnosticsRepository
+import com.manjee.linkops.infrastructure.adb.AdbShellExecutor
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * Implementation of VerificationDiagnosticsRepository
+ *
+ * Orchestrates device ADB queries, assetlinks.json fetching,
+ * fingerprint comparison, and failure analysis.
+ */
+class VerificationDiagnosticsRepositoryImpl(
+    private val adbExecutor: AdbShellExecutor,
+    private val strategyFactory: AdbCommandStrategyFactory,
+    private val getAppLinksParser: GetAppLinksParser,
+    private val dumpsysParser: DumpsysParser,
+    private val assetLinksRepository: AssetLinksRepository,
+    private val fingerprintComparator: CertificateFingerprintComparator,
+    private val failureAnalyzer: VerificationFailureAnalyzer
+) : VerificationDiagnosticsRepository {
+
+    companion object {
+        private const val ANDROID_12_SDK_LEVEL = 31
+    }
+
+    override suspend fun analyzeVerification(
+        deviceSerial: String,
+        packageName: String
+    ): Result<VerificationDiagnostics> = runCatching {
+        // 1. Get device SDK level
+        val sdkLevel = getSdkLevel(deviceSerial)
+            .getOrElse { throw it }
+
+        // 2. Get app links (including fingerprint on Android 12+)
+        val strategy = strategyFactory.create(sdkLevel)
+        val command = strategy.getAppLinksCommand(packageName)
+        val appLinks = adbExecutor.executeOnDevice(deviceSerial, command)
+            .mapCatching { output ->
+                if (sdkLevel >= ANDROID_12_SDK_LEVEL) getAppLinksParser.parse(output)
+                else dumpsysParser.parse(output)
+            }
+            .getOrElse { throw it }
+
+        // 3. Find the target package
+        val appLink = appLinks.find { it.packageName == packageName }
+            ?: throw IllegalStateException("Package $packageName not found in app links")
+
+        // 4. Extract local fingerprint (available on Android 12+ from Signatures field)
+        val localFingerprint = appLink.domains.firstOrNull()?.fingerprint
+
+        // 5. For each domain, fetch assetlinks.json and analyze (concurrently)
+        val domainResults = coroutineScope {
+            appLink.domains.map { domainVerification ->
+                async {
+                    analyzeDomain(
+                        domainVerification = domainVerification,
+                        packageName = packageName,
+                        localFingerprint = localFingerprint
+                    )
+                }
+            }.awaitAll()
+        }
+
+        VerificationDiagnostics(
+            packageName = packageName,
+            deviceSerial = deviceSerial,
+            domainResults = domainResults,
+            localFingerprint = localFingerprint
+        )
+    }
+
+    private suspend fun analyzeDomain(
+        domainVerification: DomainVerification,
+        packageName: String,
+        localFingerprint: String?
+    ): DomainDiagnosticResult {
+        val domain = domainVerification.domain
+
+        // Fetch and validate assetlinks.json
+        val validationResult = assetLinksRepository.validateAssetLinks(domain)
+
+        val validation = validationResult.getOrNull()
+        val assetLinksStatus = mapValidationStatus(validation?.status)
+        val assetLinksContent = validation?.content
+
+        // Compare fingerprints
+        val fingerprintResult = fingerprintComparator.compare(
+            localFingerprint = localFingerprint,
+            packageName = packageName,
+            assetLinksContent = assetLinksContent
+        )
+
+        // Analyze failures
+        val (failureReasons, suggestions) = failureAnalyzer.analyze(
+            verificationState = domainVerification.verificationState,
+            fingerprintResult = fingerprintResult,
+            assetLinksStatus = assetLinksStatus,
+            packageName = packageName,
+            domain = domain
+        )
+
+        return DomainDiagnosticResult(
+            domain = domain,
+            verificationState = domainVerification.verificationState,
+            fingerprintComparison = fingerprintResult,
+            assetLinksStatus = assetLinksStatus,
+            failureReasons = failureReasons,
+            suggestions = suggestions
+        )
+    }
+
+    private fun mapValidationStatus(status: ValidationStatus?): AssetLinksStatus {
+        return when (status) {
+            ValidationStatus.VALID -> AssetLinksStatus.VALID
+            ValidationStatus.NOT_FOUND -> AssetLinksStatus.NOT_FOUND
+            ValidationStatus.INVALID_JSON -> AssetLinksStatus.INVALID_JSON
+            ValidationStatus.NETWORK_ERROR -> AssetLinksStatus.NETWORK_ERROR
+            ValidationStatus.REDIRECT -> AssetLinksStatus.REDIRECT
+            ValidationStatus.FINGERPRINT_MISMATCH -> AssetLinksStatus.INVALID_JSON
+            ValidationStatus.INVALID_CONTENT_TYPE -> AssetLinksStatus.VALID
+            null -> AssetLinksStatus.NETWORK_ERROR
+        }
+    }
+
+    private suspend fun getSdkLevel(deviceSerial: String): Result<Int> {
+        return adbExecutor
+            .executeOnDevice(deviceSerial, "getprop ro.build.version.sdk")
+            .mapCatching { output ->
+                output.trim().toIntOrNull()
+                    ?: throw IllegalStateException("Failed to parse SDK level: $output")
+            }
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/domain/model/VerificationDiagnostics.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/domain/model/VerificationDiagnostics.kt
@@ -1,0 +1,107 @@
+package com.manjee.linkops.domain.model
+
+/**
+ * Complete verification diagnostics result for a device
+ *
+ * Combines per-domain verification status, certificate fingerprint comparison,
+ * and root cause analysis into a single result.
+ *
+ * @param packageName The Android package name analyzed
+ * @param deviceSerial The device serial used for analysis
+ * @param domainResults Per-domain verification results
+ * @param localFingerprint SHA256 certificate fingerprint extracted from the device
+ */
+data class VerificationDiagnostics(
+    val packageName: String,
+    val deviceSerial: String,
+    val domainResults: List<DomainDiagnosticResult>,
+    val localFingerprint: String?
+) {
+    val totalDomains: Int get() = domainResults.size
+    val verifiedDomains: Int get() = domainResults.count { it.verificationState.isSuccessful }
+    val failedDomains: Int get() = totalDomains - verifiedDomains
+    val hasIssues: Boolean get() = domainResults.any { it.failureReasons.isNotEmpty() }
+}
+
+/**
+ * Diagnostic result for a single domain
+ *
+ * @param domain The domain name
+ * @param verificationState Device-reported verification state
+ * @param fingerprintComparison Result of fingerprint comparison with assetlinks.json
+ * @param assetLinksStatus Validation status of the domain's assetlinks.json
+ * @param failureReasons Identified root causes for verification failure
+ * @param suggestions Actionable suggestions to fix the issue
+ */
+data class DomainDiagnosticResult(
+    val domain: String,
+    val verificationState: VerificationState,
+    val fingerprintComparison: FingerprintComparisonResult,
+    val assetLinksStatus: AssetLinksStatus,
+    val failureReasons: List<FailureReason>,
+    val suggestions: List<String>
+)
+
+/**
+ * Result of comparing local APK fingerprint against remote assetlinks.json fingerprints
+ */
+sealed class FingerprintComparisonResult {
+    /**
+     * Local fingerprint matches one in assetlinks.json
+     */
+    data object Match : FingerprintComparisonResult()
+
+    /**
+     * Local fingerprint does not match any in assetlinks.json
+     *
+     * @param localFingerprint SHA256 from the device
+     * @param remoteFingerprints SHA256 values from assetlinks.json
+     */
+    data class Mismatch(
+        val localFingerprint: String,
+        val remoteFingerprints: List<String>
+    ) : FingerprintComparisonResult()
+
+    /**
+     * No fingerprint available on the device (e.g., Android 11)
+     */
+    data object NoLocalFingerprint : FingerprintComparisonResult()
+
+    /**
+     * assetlinks.json could not be fetched or parsed
+     */
+    data object RemoteUnavailable : FingerprintComparisonResult()
+
+    /**
+     * assetlinks.json has no fingerprints for this package
+     */
+    data object NoRemoteFingerprint : FingerprintComparisonResult()
+
+    val isMatch: Boolean get() = this is Match
+}
+
+/**
+ * Status of a domain's assetlinks.json
+ */
+enum class AssetLinksStatus {
+    VALID,
+    NOT_FOUND,
+    INVALID_JSON,
+    NETWORK_ERROR,
+    REDIRECT,
+    NOT_CHECKED
+}
+
+/**
+ * Identified failure reason for domain verification
+ */
+enum class FailureReason {
+    ASSET_LINKS_MISSING,
+    ASSET_LINKS_INVALID_JSON,
+    ASSET_LINKS_NETWORK_ERROR,
+    ASSET_LINKS_REDIRECT,
+    FINGERPRINT_MISMATCH,
+    PACKAGE_NOT_IN_ASSET_LINKS,
+    DNS_FAILURE,
+    UNKNOWN
+}

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/domain/repository/VerificationDiagnosticsRepository.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/domain/repository/VerificationDiagnosticsRepository.kt
@@ -1,0 +1,26 @@
+package com.manjee.linkops.domain.repository
+
+import com.manjee.linkops.domain.model.VerificationDiagnostics
+
+/**
+ * Repository for performing deep verification diagnostics
+ */
+interface VerificationDiagnosticsRepository {
+    /**
+     * Analyze verification status for all domains of a package on a device
+     *
+     * Performs:
+     * 1. Fetches domain verification states from the device
+     * 2. Extracts local APK certificate fingerprint
+     * 3. Fetches and compares assetlinks.json for each domain
+     * 4. Identifies failure root causes and generates suggestions
+     *
+     * @param deviceSerial Device serial number
+     * @param packageName Android package name to analyze
+     * @return Complete diagnostics result or error
+     */
+    suspend fun analyzeVerification(
+        deviceSerial: String,
+        packageName: String
+    ): Result<VerificationDiagnostics>
+}

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/domain/usecase/diagnostics/AnalyzeVerificationUseCase.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/domain/usecase/diagnostics/AnalyzeVerificationUseCase.kt
@@ -1,0 +1,27 @@
+package com.manjee.linkops.domain.usecase.diagnostics
+
+import com.manjee.linkops.domain.model.VerificationDiagnostics
+import com.manjee.linkops.domain.repository.VerificationDiagnosticsRepository
+
+/**
+ * Use case for performing deep verification analysis on a package
+ *
+ * @param verificationDiagnosticsRepository Repository for diagnostics operations
+ */
+class AnalyzeVerificationUseCase(
+    private val verificationDiagnosticsRepository: VerificationDiagnosticsRepository
+) {
+    /**
+     * Analyze verification status for a package on a device
+     *
+     * @param deviceSerial Device serial number
+     * @param packageName Android package name to analyze
+     * @return Complete diagnostics result
+     */
+    suspend operator fun invoke(
+        deviceSerial: String,
+        packageName: String
+    ): Result<VerificationDiagnostics> {
+        return verificationDiagnosticsRepository.analyzeVerification(deviceSerial, packageName)
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/navigation/NavGraph.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/navigation/NavGraph.kt
@@ -119,4 +119,5 @@ fun ProvideNavigationController(
 fun NavigationController.navigateToDashboard() = navigateTo(Screen.Dashboard)
 fun NavigationController.navigateToDeviceSelection() = navigateTo(Screen.DeviceSelection)
 fun NavigationController.navigateToDiagnostics() = navigateTo(Screen.Diagnostics)
+fun NavigationController.navigateToVerificationDeepDive() = navigateTo(Screen.VerificationDeepDive)
 fun NavigationController.navigateToSettings() = navigateTo(Screen.Settings)

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/navigation/Screen.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/navigation/Screen.kt
@@ -32,6 +32,11 @@ sealed class Screen(val route: String, val title: String) {
     data object ManifestAnalyzer : Screen("manifest_analyzer", "Manifest Analyzer")
 
     /**
+     * Verification deep dive screen - for deep verification analysis
+     */
+    data object VerificationDeepDive : Screen("verification_deep_dive", "Verification Deep Dive")
+
+    /**
      * Settings screen
      */
     data object Settings : Screen("settings", "Settings")

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/screen/diagnostics/VerificationDeepDiveScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/screen/diagnostics/VerificationDeepDiveScreen.kt
@@ -1,0 +1,647 @@
+package com.manjee.linkops.ui.screen.diagnostics
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.manjee.linkops.domain.model.*
+import com.manjee.linkops.ui.component.EmptyState
+import com.manjee.linkops.ui.component.LoadingOverlay
+import com.manjee.linkops.ui.component.StatusDot
+import com.manjee.linkops.ui.theme.LinkOpsColors
+
+/**
+ * Verification Deep Dive Screen
+ *
+ * Provides deep verification analysis for a specific package, including:
+ * - Per-domain verification status
+ * - Certificate fingerprint comparison
+ * - Root cause analysis with actionable suggestions
+ */
+@Composable
+fun VerificationDeepDiveScreen(
+    viewModel: VerificationDeepDiveViewModel,
+    devices: List<Device>,
+    modifier: Modifier = Modifier
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    // Sync device selection from available devices
+    LaunchedEffect(devices) {
+        if (uiState.selectedDevice == null) {
+            devices.firstOrNull { it.isAvailable }?.let { viewModel.selectDevice(it) }
+        }
+    }
+
+    Row(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        // Left Panel - Input
+        Column(
+            modifier = Modifier
+                .weight(0.35f)
+                .fillMaxHeight()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = "Verification Deep Dive",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            HorizontalDivider()
+
+            InputSection(
+                packageName = uiState.packageName,
+                onPackageNameChange = { viewModel.updatePackageName(it) },
+                devices = devices,
+                selectedDevice = uiState.selectedDevice,
+                onDeviceSelected = { viewModel.selectDevice(it) },
+                onAnalyze = { viewModel.analyzeVerification() },
+                isLoading = uiState.isLoading,
+                error = uiState.error
+            )
+
+            // Summary card when diagnostics are available
+            if (uiState.diagnostics != null) {
+                HorizontalDivider()
+                SummaryCard(uiState.diagnostics!!)
+            }
+        }
+
+        // Right Panel - Results
+        Column(
+            modifier = Modifier
+                .weight(0.65f)
+                .fillMaxHeight()
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(16.dp)
+        ) {
+            DiagnosticsResultsPanel(
+                diagnostics = uiState.diagnostics,
+                isLoading = uiState.isLoading,
+                onClear = { viewModel.clearResult() }
+            )
+        }
+    }
+
+    LoadingOverlay(
+        isLoading = uiState.isLoading,
+        message = "Analyzing verification status..."
+    )
+}
+
+/**
+ * Input section for device and package selection
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun InputSection(
+    packageName: String,
+    onPackageNameChange: (String) -> Unit,
+    devices: List<Device>,
+    selectedDevice: Device?,
+    onDeviceSelected: (Device) -> Unit,
+    onAnalyze: () -> Unit,
+    isLoading: Boolean,
+    error: String?
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = "Analysis Target",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold
+        )
+
+        // Device selector
+        val availableDevices = devices.filter { it.isAvailable }
+        if (availableDevices.isNotEmpty()) {
+            var expanded by remember { mutableStateOf(false) }
+
+            ExposedDropdownMenuBox(
+                expanded = expanded,
+                onExpandedChange = { expanded = it }
+            ) {
+                OutlinedTextField(
+                    value = selectedDevice?.displayName ?: "Select a device",
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Device") },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .menuAnchor()
+                )
+
+                ExposedDropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false }
+                ) {
+                    availableDevices.forEach { device ->
+                        DropdownMenuItem(
+                            text = { Text(device.displayName) },
+                            onClick = {
+                                onDeviceSelected(device)
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+        } else {
+            Text(
+                text = "No devices available. Connect a device first.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error
+            )
+        }
+
+        // Package name input
+        OutlinedTextField(
+            value = packageName,
+            onValueChange = onPackageNameChange,
+            label = { Text("Package Name") },
+            placeholder = { Text("com.example.app") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            leadingIcon = {
+                Icon(Icons.Default.Search, contentDescription = null)
+            },
+            trailingIcon = {
+                if (packageName.isNotEmpty()) {
+                    IconButton(onClick = { onPackageNameChange("") }) {
+                        Icon(Icons.Default.Clear, contentDescription = "Clear")
+                    }
+                }
+            },
+            isError = error != null,
+            supportingText = if (error != null) {
+                { Text(error, color = MaterialTheme.colorScheme.error) }
+            } else null
+        )
+
+        Button(
+            onClick = onAnalyze,
+            enabled = !isLoading && packageName.isNotBlank() && selectedDevice != null,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Analyze Verification")
+        }
+
+        Text(
+            text = "Analyzes domain verification status, compares certificate fingerprints, and identifies failure root causes.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+/**
+ * Summary card showing overall diagnostics status
+ */
+@Composable
+private fun SummaryCard(diagnostics: VerificationDiagnostics) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "Summary",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                SummaryItem(
+                    label = "Total Domains",
+                    value = "${diagnostics.totalDomains}",
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                SummaryItem(
+                    label = "Verified",
+                    value = "${diagnostics.verifiedDomains}",
+                    color = LinkOpsColors.Success
+                )
+                SummaryItem(
+                    label = "Failed",
+                    value = "${diagnostics.failedDomains}",
+                    color = if (diagnostics.failedDomains > 0) LinkOpsColors.Error
+                    else MaterialTheme.colorScheme.onSurface
+                )
+            }
+
+            if (diagnostics.localFingerprint != null) {
+                HorizontalDivider()
+                Text(
+                    text = "Local Fingerprint",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                SelectionContainer {
+                    Text(
+                        text = diagnostics.localFingerprint,
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            fontFamily = FontFamily.Monospace,
+                            fontSize = 10.sp
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Summary stat item
+ */
+@Composable
+private fun SummaryItem(
+    label: String,
+    value: String,
+    color: androidx.compose.ui.graphics.Color
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = color
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+/**
+ * Results panel showing per-domain diagnostics
+ */
+@Composable
+private fun DiagnosticsResultsPanel(
+    diagnostics: VerificationDiagnostics?,
+    isLoading: Boolean,
+    onClear: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Domain Analysis",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            if (diagnostics != null) {
+                IconButton(onClick = onClear) {
+                    Icon(Icons.Default.Clear, contentDescription = "Clear")
+                }
+            }
+        }
+
+        if (diagnostics == null && !isLoading) {
+            EmptyState(
+                title = "No analysis results",
+                description = "Select a device and package, then click Analyze",
+                icon = Icons.Default.Search
+            )
+        } else if (diagnostics != null) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(diagnostics.domainResults) { result ->
+                    DomainDiagnosticCard(result)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Card displaying diagnostics for a single domain
+ */
+@Composable
+private fun DomainDiagnosticCard(result: DomainDiagnosticResult) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            // Domain header with status
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                StatusDot(
+                    color = verificationStateColor(result.verificationState),
+                    size = 12
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(
+                    text = result.domain,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f)
+                )
+                VerificationStatusChip(result.verificationState)
+            }
+
+            HorizontalDivider()
+
+            // AssetLinks status
+            AssetLinksStatusRow(result.assetLinksStatus)
+
+            // Fingerprint comparison
+            FingerprintComparisonRow(result.fingerprintComparison)
+
+            // Failure reasons and suggestions
+            if (result.failureReasons.isNotEmpty()) {
+                HorizontalDivider()
+                FailureReasonsSection(result.failureReasons, result.suggestions)
+            }
+        }
+    }
+}
+
+/**
+ * Chip showing verification state
+ */
+@Composable
+private fun VerificationStatusChip(state: VerificationState) {
+    val (text, color) = when (state) {
+        VerificationState.VERIFIED -> "Verified" to LinkOpsColors.Success
+        VerificationState.APPROVED -> "Approved" to LinkOpsColors.Success
+        VerificationState.DENIED -> "Denied" to LinkOpsColors.Error
+        VerificationState.UNVERIFIED -> "Unverified" to LinkOpsColors.Warning
+        VerificationState.LEGACY_FAILURE -> "Failed" to LinkOpsColors.Error
+        VerificationState.UNKNOWN -> "Unknown" to LinkOpsColors.Unknown
+    }
+
+    Box(
+        modifier = Modifier
+            .background(color.copy(alpha = 0.1f), RoundedCornerShape(4.dp))
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            color = color,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+/**
+ * Row showing assetlinks.json status
+ */
+@Composable
+private fun AssetLinksStatusRow(status: AssetLinksStatus) {
+    val (statusText, color) = when (status) {
+        AssetLinksStatus.VALID -> "Valid" to LinkOpsColors.Success
+        AssetLinksStatus.NOT_FOUND -> "Not Found (404)" to LinkOpsColors.Error
+        AssetLinksStatus.INVALID_JSON -> "Invalid JSON" to LinkOpsColors.Error
+        AssetLinksStatus.NETWORK_ERROR -> "Network Error" to LinkOpsColors.Error
+        AssetLinksStatus.REDIRECT -> "Redirect (not allowed)" to LinkOpsColors.Warning
+        AssetLinksStatus.NOT_CHECKED -> "Not Checked" to LinkOpsColors.Unknown
+    }
+
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = "assetlinks.json: ",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        StatusDot(color = color)
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = statusText,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Medium,
+            color = color
+        )
+    }
+}
+
+/**
+ * Row showing fingerprint comparison result
+ */
+@Composable
+private fun FingerprintComparisonRow(result: FingerprintComparisonResult) {
+    val (statusText, color) = when (result) {
+        is FingerprintComparisonResult.Match -> "Match" to LinkOpsColors.Success
+        is FingerprintComparisonResult.Mismatch -> "Mismatch" to LinkOpsColors.Error
+        is FingerprintComparisonResult.NoLocalFingerprint ->
+            "No local fingerprint (Android 11)" to LinkOpsColors.Unknown
+        is FingerprintComparisonResult.RemoteUnavailable ->
+            "Remote unavailable" to LinkOpsColors.Warning
+        is FingerprintComparisonResult.NoRemoteFingerprint ->
+            "Package not in assetlinks.json" to LinkOpsColors.Error
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "Fingerprint: ",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            StatusDot(color = color)
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = statusText,
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Medium,
+                color = color
+            )
+        }
+
+        // Show mismatch details
+        if (result is FingerprintComparisonResult.Mismatch) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        LinkOpsColors.Error.copy(alpha = 0.05f),
+                        RoundedCornerShape(8.dp)
+                    )
+                    .padding(10.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = "Local APK:",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                SelectionContainer {
+                    Text(
+                        text = result.localFingerprint,
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            fontFamily = FontFamily.Monospace,
+                            fontSize = 10.sp
+                        ),
+                        color = LinkOpsColors.Error
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Text(
+                    text = "Remote assetlinks.json (${result.remoteFingerprints.size}):",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                result.remoteFingerprints.forEach { fp ->
+                    SelectionContainer {
+                        Text(
+                            text = fp,
+                            style = MaterialTheme.typography.bodySmall.copy(
+                                fontFamily = FontFamily.Monospace,
+                                fontSize = 10.sp
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Section showing failure reasons and actionable suggestions
+ */
+@Composable
+private fun FailureReasonsSection(
+    reasons: List<FailureReason>,
+    suggestions: List<String>
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = "Root Cause Analysis",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = LinkOpsColors.Error
+        )
+
+        // Failure reasons
+        reasons.forEach { reason ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        LinkOpsColors.Error.copy(alpha = 0.08f),
+                        RoundedCornerShape(6.dp)
+                    )
+                    .padding(10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(text = "!", color = LinkOpsColors.Error, fontWeight = FontWeight.Bold)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = formatFailureReason(reason),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+
+        // Suggestions
+        if (suggestions.isNotEmpty()) {
+            Text(
+                text = "Suggestions",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = LinkOpsColors.Info
+            )
+
+            suggestions.forEach { suggestion ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(
+                            LinkOpsColors.Info.copy(alpha = 0.08f),
+                            RoundedCornerShape(6.dp)
+                        )
+                        .padding(10.dp),
+                    verticalAlignment = Alignment.Top
+                ) {
+                    Text(
+                        text = "->",
+                        color = LinkOpsColors.Info,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = suggestion,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Format failure reason enum to human-readable text
+ */
+private fun formatFailureReason(reason: FailureReason): String {
+    return when (reason) {
+        FailureReason.ASSET_LINKS_MISSING -> "assetlinks.json not found"
+        FailureReason.ASSET_LINKS_INVALID_JSON -> "assetlinks.json has invalid JSON"
+        FailureReason.ASSET_LINKS_NETWORK_ERROR -> "Cannot reach domain server"
+        FailureReason.ASSET_LINKS_REDIRECT -> "assetlinks.json served via redirect"
+        FailureReason.FINGERPRINT_MISMATCH -> "Certificate fingerprint mismatch"
+        FailureReason.PACKAGE_NOT_IN_ASSET_LINKS -> "Package not declared in assetlinks.json"
+        FailureReason.DNS_FAILURE -> "DNS resolution failed"
+        FailureReason.UNKNOWN -> "Unknown failure reason"
+    }
+}
+
+/**
+ * Get color for verification state
+ */
+private fun verificationStateColor(state: VerificationState): androidx.compose.ui.graphics.Color {
+    return when (state) {
+        VerificationState.VERIFIED, VerificationState.APPROVED -> LinkOpsColors.Success
+        VerificationState.DENIED, VerificationState.LEGACY_FAILURE -> LinkOpsColors.Error
+        VerificationState.UNVERIFIED -> LinkOpsColors.Warning
+        VerificationState.UNKNOWN -> LinkOpsColors.Unknown
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/screen/diagnostics/VerificationDeepDiveViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/com/manjee/linkops/ui/screen/diagnostics/VerificationDeepDiveViewModel.kt
@@ -1,0 +1,96 @@
+package com.manjee.linkops.ui.screen.diagnostics
+
+import com.manjee.linkops.di.AppContainer
+import com.manjee.linkops.domain.model.Device
+import com.manjee.linkops.domain.model.VerificationDiagnostics
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+
+/**
+ * UI State for Verification Deep Dive
+ */
+data class VerificationDeepDiveUiState(
+    val packageName: String = "",
+    val selectedDevice: Device? = null,
+    val isLoading: Boolean = false,
+    val diagnostics: VerificationDiagnostics? = null,
+    val error: String? = null
+)
+
+/**
+ * ViewModel for Verification Deep Dive feature
+ *
+ * Handles deep verification analysis for a specific package on a selected device,
+ * including domain status tracking, fingerprint comparison, and failure root cause analysis.
+ */
+class VerificationDeepDiveViewModel {
+    private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    private val _uiState = MutableStateFlow(VerificationDeepDiveUiState())
+    val uiState: StateFlow<VerificationDeepDiveUiState> = _uiState.asStateFlow()
+
+    /**
+     * Update package name input
+     */
+    fun updatePackageName(packageName: String) {
+        _uiState.update { it.copy(packageName = packageName, error = null) }
+    }
+
+    /**
+     * Set the selected device for analysis
+     */
+    fun selectDevice(device: Device?) {
+        _uiState.update { it.copy(selectedDevice = device, error = null) }
+    }
+
+    /**
+     * Run deep verification analysis
+     */
+    fun analyzeVerification() {
+        val device = _uiState.value.selectedDevice
+        val packageName = _uiState.value.packageName.trim()
+
+        if (device == null) {
+            _uiState.update { it.copy(error = "Please select a device first") }
+            return
+        }
+
+        if (packageName.isBlank()) {
+            _uiState.update { it.copy(error = "Please enter a package name") }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null, diagnostics = null) }
+
+            AppContainer.analyzeVerificationUseCase(device.serialNumber, packageName)
+                .onSuccess { diagnostics ->
+                    _uiState.update {
+                        it.copy(isLoading = false, diagnostics = diagnostics)
+                    }
+                }
+                .onFailure { error ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = error.message ?: "Analysis failed"
+                        )
+                    }
+                }
+        }
+    }
+
+    /**
+     * Clear current diagnostics result
+     */
+    fun clearResult() {
+        _uiState.update { it.copy(diagnostics = null, error = null) }
+    }
+
+    /**
+     * Cleanup resources
+     */
+    fun onCleared() {
+        viewModelScope.cancel()
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/com/manjee/linkops/data/analyzer/CertificateFingerprintComparatorTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/manjee/linkops/data/analyzer/CertificateFingerprintComparatorTest.kt
@@ -1,0 +1,140 @@
+package com.manjee.linkops.data.analyzer
+
+import com.manjee.linkops.domain.model.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class CertificateFingerprintComparatorTest {
+
+    private val comparator = CertificateFingerprintComparator()
+
+    private fun createContent(packageName: String, fingerprints: List<String>): AssetLinksContent {
+        return AssetLinksContent(
+            statements = listOf(
+                AssetStatement(
+                    relation = listOf("delegate_permission/common.handle_all_urls"),
+                    target = AssetTarget(
+                        namespace = "android_app",
+                        packageName = packageName,
+                        sha256CertFingerprints = fingerprints
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `compare should return Match when fingerprints are equal`() {
+        val fingerprint = "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89"
+        val content = createContent("com.example.app", listOf(fingerprint))
+
+        val result = comparator.compare(fingerprint, "com.example.app", content)
+
+        assertIs<FingerprintComparisonResult.Match>(result)
+    }
+
+    @Test
+    fun `compare should match case-insensitive fingerprints`() {
+        val localFp = "ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67:89"
+        val remoteFp = "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89"
+        val content = createContent("com.example.app", listOf(remoteFp))
+
+        val result = comparator.compare(localFp, "com.example.app", content)
+
+        assertIs<FingerprintComparisonResult.Match>(result)
+    }
+
+    @Test
+    fun `compare should match fingerprints with and without colons`() {
+        val localFp = "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+        val remoteFp = "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89"
+        val content = createContent("com.example.app", listOf(remoteFp))
+
+        val result = comparator.compare(localFp, "com.example.app", content)
+
+        assertIs<FingerprintComparisonResult.Match>(result)
+    }
+
+    @Test
+    fun `compare should return Mismatch when fingerprints differ`() {
+        val localFp = "AA:BB:CC:DD"
+        val remoteFp = "11:22:33:44"
+        val content = createContent("com.example.app", listOf(remoteFp))
+
+        val result = comparator.compare(localFp, "com.example.app", content)
+
+        assertIs<FingerprintComparisonResult.Mismatch>(result)
+        assertEquals(localFp, result.localFingerprint)
+        assertEquals(listOf(remoteFp), result.remoteFingerprints)
+    }
+
+    @Test
+    fun `compare should match against any of multiple remote fingerprints`() {
+        val localFp = "CC:DD:EE:FF"
+        val content = createContent("com.example.app", listOf("AA:BB", "CC:DD:EE:FF", "11:22"))
+
+        val result = comparator.compare(localFp, "com.example.app", content)
+
+        assertIs<FingerprintComparisonResult.Match>(result)
+    }
+
+    @Test
+    fun `compare should return NoLocalFingerprint when local is null`() {
+        val content = createContent("com.example.app", listOf("AA:BB"))
+
+        val result = comparator.compare(null, "com.example.app", content)
+
+        assertIs<FingerprintComparisonResult.NoLocalFingerprint>(result)
+    }
+
+    @Test
+    fun `compare should return RemoteUnavailable when content is null`() {
+        val result = comparator.compare("AA:BB", "com.example.app", null)
+
+        assertIs<FingerprintComparisonResult.RemoteUnavailable>(result)
+    }
+
+    @Test
+    fun `compare should return NoRemoteFingerprint when package not found in content`() {
+        val content = createContent("com.other.app", listOf("AA:BB"))
+
+        val result = comparator.compare("AA:BB", "com.example.app", content)
+
+        assertIs<FingerprintComparisonResult.NoRemoteFingerprint>(result)
+    }
+
+    @Test
+    fun `compare should return NoRemoteFingerprint when content has empty fingerprints`() {
+        val content = createContent("com.example.app", emptyList())
+
+        val result = comparator.compare("AA:BB", "com.example.app", content)
+
+        assertIs<FingerprintComparisonResult.NoRemoteFingerprint>(result)
+    }
+
+    @Test
+    fun `normalizeFingerprint should remove colons and uppercase`() {
+        val normalized = CertificateFingerprintComparator.normalizeFingerprint("ab:cd:ef:01")
+        assertEquals("ABCDEF01", normalized)
+    }
+
+    @Test
+    fun `normalizeFingerprint should handle already normalized fingerprint`() {
+        val normalized = CertificateFingerprintComparator.normalizeFingerprint("ABCDEF01")
+        assertEquals("ABCDEF01", normalized)
+    }
+
+    @Test
+    fun `isMatch property should return true for Match`() {
+        val match = FingerprintComparisonResult.Match
+        assertTrue(match.isMatch)
+    }
+
+    @Test
+    fun `isMatch property should return false for Mismatch`() {
+        val mismatch = FingerprintComparisonResult.Mismatch("AA", listOf("BB"))
+        assertTrue(!mismatch.isMatch)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/com/manjee/linkops/data/analyzer/VerificationFailureAnalyzerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/manjee/linkops/data/analyzer/VerificationFailureAnalyzerTest.kt
@@ -1,0 +1,199 @@
+package com.manjee.linkops.data.analyzer
+
+import com.manjee.linkops.domain.model.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class VerificationFailureAnalyzerTest {
+
+    private val analyzer = VerificationFailureAnalyzer()
+
+    @Test
+    fun `analyze should return empty results for verified domain`() {
+        val (reasons, suggestions) = analyzer.analyze(
+            verificationState = VerificationState.VERIFIED,
+            fingerprintResult = FingerprintComparisonResult.Match,
+            assetLinksStatus = AssetLinksStatus.VALID,
+            packageName = "com.example.app",
+            domain = "example.com"
+        )
+
+        assertTrue(reasons.isEmpty(), "No failure reasons for verified domain")
+        assertTrue(suggestions.isEmpty(), "No suggestions for verified domain")
+    }
+
+    @Test
+    fun `analyze should return empty results for approved domain`() {
+        val (reasons, suggestions) = analyzer.analyze(
+            verificationState = VerificationState.APPROVED,
+            fingerprintResult = FingerprintComparisonResult.NoLocalFingerprint,
+            assetLinksStatus = AssetLinksStatus.VALID,
+            packageName = "com.example.app",
+            domain = "example.com"
+        )
+
+        assertTrue(reasons.isEmpty())
+        assertTrue(suggestions.isEmpty())
+    }
+
+    @Test
+    fun `analyze should identify missing assetlinks json`() {
+        val (reasons, suggestions) = analyzer.analyze(
+            verificationState = VerificationState.UNVERIFIED,
+            fingerprintResult = FingerprintComparisonResult.RemoteUnavailable,
+            assetLinksStatus = AssetLinksStatus.NOT_FOUND,
+            packageName = "com.example.app",
+            domain = "example.com"
+        )
+
+        assertTrue(reasons.contains(FailureReason.ASSET_LINKS_MISSING))
+        assertTrue(suggestions.any { it.contains("assetlinks.json") })
+    }
+
+    @Test
+    fun `analyze should identify invalid json in assetlinks`() {
+        val (reasons, suggestions) = analyzer.analyze(
+            verificationState = VerificationState.UNVERIFIED,
+            fingerprintResult = FingerprintComparisonResult.RemoteUnavailable,
+            assetLinksStatus = AssetLinksStatus.INVALID_JSON,
+            packageName = "com.example.app",
+            domain = "example.com"
+        )
+
+        assertTrue(reasons.contains(FailureReason.ASSET_LINKS_INVALID_JSON))
+        assertTrue(suggestions.any { it.contains("JSON syntax") })
+    }
+
+    @Test
+    fun `analyze should identify network error`() {
+        val (reasons, suggestions) = analyzer.analyze(
+            verificationState = VerificationState.UNVERIFIED,
+            fingerprintResult = FingerprintComparisonResult.RemoteUnavailable,
+            assetLinksStatus = AssetLinksStatus.NETWORK_ERROR,
+            packageName = "com.example.app",
+            domain = "example.com"
+        )
+
+        assertTrue(reasons.contains(FailureReason.ASSET_LINKS_NETWORK_ERROR))
+        assertTrue(suggestions.any { it.contains("reachable") })
+    }
+
+    @Test
+    fun `analyze should identify redirect issue`() {
+        val (reasons, suggestions) = analyzer.analyze(
+            verificationState = VerificationState.UNVERIFIED,
+            fingerprintResult = FingerprintComparisonResult.RemoteUnavailable,
+            assetLinksStatus = AssetLinksStatus.REDIRECT,
+            packageName = "com.example.app",
+            domain = "example.com"
+        )
+
+        assertTrue(reasons.contains(FailureReason.ASSET_LINKS_REDIRECT))
+        assertTrue(suggestions.any { it.contains("redirect") })
+    }
+
+    @Test
+    fun `analyze should identify fingerprint mismatch`() {
+        val (reasons, suggestions) = analyzer.analyze(
+            verificationState = VerificationState.UNVERIFIED,
+            fingerprintResult = FingerprintComparisonResult.Mismatch(
+                localFingerprint = "AA:BB",
+                remoteFingerprints = listOf("CC:DD")
+            ),
+            assetLinksStatus = AssetLinksStatus.VALID,
+            packageName = "com.example.app",
+            domain = "example.com"
+        )
+
+        assertTrue(reasons.contains(FailureReason.FINGERPRINT_MISMATCH))
+        assertTrue(suggestions.any { it.contains("fingerprint") })
+        assertTrue(suggestions.any { it.contains("AA:BB") })
+    }
+
+    @Test
+    fun `analyze should identify package not in assetlinks`() {
+        val (reasons, suggestions) = analyzer.analyze(
+            verificationState = VerificationState.UNVERIFIED,
+            fingerprintResult = FingerprintComparisonResult.NoRemoteFingerprint,
+            assetLinksStatus = AssetLinksStatus.VALID,
+            packageName = "com.example.app",
+            domain = "example.com"
+        )
+
+        assertTrue(reasons.contains(FailureReason.PACKAGE_NOT_IN_ASSET_LINKS))
+        assertTrue(suggestions.any { it.contains("com.example.app") })
+    }
+
+    @Test
+    fun `analyze should identify multiple failure reasons simultaneously`() {
+        val (reasons, _) = analyzer.analyze(
+            verificationState = VerificationState.UNVERIFIED,
+            fingerprintResult = FingerprintComparisonResult.Mismatch(
+                localFingerprint = "AA:BB",
+                remoteFingerprints = listOf("CC:DD")
+            ),
+            assetLinksStatus = AssetLinksStatus.REDIRECT,
+            packageName = "com.example.app",
+            domain = "example.com"
+        )
+
+        assertTrue(reasons.contains(FailureReason.ASSET_LINKS_REDIRECT))
+        assertTrue(reasons.contains(FailureReason.FINGERPRINT_MISMATCH))
+        assertEquals(2, reasons.size, "Should have exactly two failure reasons")
+    }
+
+    @Test
+    fun `analyze should return unknown reason when no specific cause found`() {
+        val (reasons, suggestions) = analyzer.analyze(
+            verificationState = VerificationState.DENIED,
+            fingerprintResult = FingerprintComparisonResult.Match,
+            assetLinksStatus = AssetLinksStatus.VALID,
+            packageName = "com.example.app",
+            domain = "example.com"
+        )
+
+        assertTrue(reasons.contains(FailureReason.UNKNOWN))
+        assertTrue(suggestions.isNotEmpty(), "Should have at least one suggestion")
+    }
+
+    @Test
+    fun `analyze should handle legacy failure state`() {
+        val (reasons, _) = analyzer.analyze(
+            verificationState = VerificationState.LEGACY_FAILURE,
+            fingerprintResult = FingerprintComparisonResult.NoLocalFingerprint,
+            assetLinksStatus = AssetLinksStatus.NOT_FOUND,
+            packageName = "com.example.app",
+            domain = "example.com"
+        )
+
+        assertTrue(reasons.contains(FailureReason.ASSET_LINKS_MISSING))
+    }
+
+    @Test
+    fun `analyze should handle not checked status without adding failures`() {
+        val (reasons, _) = analyzer.analyze(
+            verificationState = VerificationState.UNKNOWN,
+            fingerprintResult = FingerprintComparisonResult.NoLocalFingerprint,
+            assetLinksStatus = AssetLinksStatus.NOT_CHECKED,
+            packageName = "com.example.app",
+            domain = "example.com"
+        )
+
+        // NOT_CHECKED + NoLocalFingerprint should only yield UNKNOWN
+        assertTrue(reasons.contains(FailureReason.UNKNOWN))
+    }
+
+    @Test
+    fun `analyze suggestion should include domain name`() {
+        val (_, suggestions) = analyzer.analyze(
+            verificationState = VerificationState.UNVERIFIED,
+            fingerprintResult = FingerprintComparisonResult.RemoteUnavailable,
+            assetLinksStatus = AssetLinksStatus.NOT_FOUND,
+            packageName = "com.example.app",
+            domain = "custom.domain.com"
+        )
+
+        assertTrue(suggestions.any { it.contains("custom.domain.com") })
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/com/manjee/linkops/data/parser/GetAppLinksParserTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/manjee/linkops/data/parser/GetAppLinksParserTest.kt
@@ -1,0 +1,263 @@
+package com.manjee.linkops.data.parser
+
+import com.manjee.linkops.domain.model.VerificationState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GetAppLinksParserTest {
+
+    private val parser = GetAppLinksParser()
+
+    @Test
+    fun `parse should return empty list for empty input`() {
+        val result = parser.parse("")
+        assertTrue(result.isEmpty(), "Empty input should produce empty list")
+    }
+
+    @Test
+    fun `parse should return empty list for ADB error message`() {
+        val result = parser.parse("error: device not found")
+        assertTrue(result.isEmpty(), "ADB error should produce empty list")
+    }
+
+    @Test
+    fun `parse should return empty list for permission denied response`() {
+        val result = parser.parse("Permission denied")
+        assertTrue(result.isEmpty(), "Permission denied should produce empty list")
+    }
+
+    @Test
+    fun `parse should return empty list for operation not permitted response`() {
+        val result = parser.parse("Operation not permitted")
+        assertTrue(result.isEmpty(), "Operation not permitted should produce empty list")
+    }
+
+    @Test
+    fun `parse should handle single package with verified domain`() {
+        val output = """
+            com.example.app:
+              ID: 12345678-1234-1234-1234-123456789012
+              Signatures: [AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89]
+              Domain verification state:
+                example.com: verified
+        """.trimIndent()
+
+        val result = parser.parse(output)
+
+        assertEquals(1, result.size, "Should parse one package")
+        assertEquals("com.example.app", result[0].packageName)
+        assertEquals(1, result[0].domains.size)
+        assertEquals("example.com", result[0].domains[0].domain)
+        assertEquals(VerificationState.VERIFIED, result[0].domains[0].verificationState)
+        assertEquals(
+            "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89",
+            result[0].domains[0].fingerprint
+        )
+    }
+
+    @Test
+    fun `parse should handle multiple domains with different states`() {
+        val output = """
+            com.example.app:
+              ID: 12345678-1234-1234-1234-123456789012
+              Signatures: [AA:BB:CC:DD]
+              Domain verification state:
+                example.com: verified
+                test.example.com: none
+                staging.example.com: legacy_failure
+        """.trimIndent()
+
+        val result = parser.parse(output)
+
+        assertEquals(1, result.size)
+        assertEquals(3, result[0].domains.size)
+        assertEquals(VerificationState.VERIFIED, result[0].domains[0].verificationState)
+        assertEquals(VerificationState.UNVERIFIED, result[0].domains[1].verificationState)
+        assertEquals(VerificationState.LEGACY_FAILURE, result[0].domains[2].verificationState)
+    }
+
+    @Test
+    fun `parse should attach fingerprint to all domains of a package`() {
+        val fingerprint = "AA:BB:CC:DD:EE:FF"
+        val output = """
+            com.example.app:
+              ID: 12345678
+              Signatures: [$fingerprint]
+              Domain verification state:
+                example.com: verified
+                test.example.com: none
+        """.trimIndent()
+
+        val result = parser.parse(output)
+
+        assertEquals(1, result.size)
+        result[0].domains.forEach { domain ->
+            assertEquals(fingerprint, domain.fingerprint, "Each domain should have the fingerprint")
+        }
+    }
+
+    @Test
+    fun `parse should handle multiple packages`() {
+        val output = """
+            com.example.app1:
+              ID: 11111111
+              Signatures: [AA:BB]
+              Domain verification state:
+                example.com: verified
+            com.example.app2:
+              ID: 22222222
+              Signatures: [CC:DD]
+              Domain verification state:
+                test.com: none
+        """.trimIndent()
+
+        val result = parser.parse(output)
+
+        assertEquals(2, result.size)
+        assertEquals("com.example.app1", result[0].packageName)
+        assertEquals("AA:BB", result[0].domains[0].fingerprint)
+        assertEquals("com.example.app2", result[1].packageName)
+        assertEquals("CC:DD", result[1].domains[0].fingerprint)
+    }
+
+    @Test
+    fun `parse should handle package without signatures field`() {
+        val output = """
+            com.example.app:
+              ID: 12345678
+              Domain verification state:
+                example.com: verified
+        """.trimIndent()
+
+        val result = parser.parse(output)
+
+        assertEquals(1, result.size)
+        assertNull(result[0].domains[0].fingerprint, "Fingerprint should be null when Signatures is missing")
+    }
+
+    @Test
+    fun `parse should handle empty signatures brackets`() {
+        val output = """
+            com.example.app:
+              ID: 12345678
+              Signatures: []
+              Domain verification state:
+                example.com: verified
+        """.trimIndent()
+
+        val result = parser.parse(output)
+
+        assertEquals(1, result.size)
+        assertNull(result[0].domains[0].fingerprint, "Empty brackets should produce null fingerprint")
+    }
+
+    @Test
+    fun `parse should handle unknown verification state`() {
+        val output = """
+            com.example.app:
+              ID: 12345678
+              Signatures: [AA:BB]
+              Domain verification state:
+                example.com: some_future_state
+        """.trimIndent()
+
+        val result = parser.parse(output)
+
+        assertEquals(1, result.size)
+        assertEquals(VerificationState.UNKNOWN, result[0].domains[0].verificationState)
+    }
+
+    @Test
+    fun `parse should handle truncated output gracefully`() {
+        val output = """
+            com.example.app:
+              ID: 12345678
+              Signatures: [AA:BB]
+              Domain verification sta
+        """.trimIndent()
+
+        val result = parser.parse(output)
+        // Truncated output without complete domain section should yield empty domains
+        assertTrue(result.isEmpty(), "Truncated output should not produce incomplete results")
+    }
+
+    @Test
+    fun `parse should handle special characters in output`() {
+        val output = """
+            com.example.app:
+              ID: 12345678
+              Signatures: [AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99]
+              Domain verification state:
+                sub-domain.example.co.uk: verified
+        """.trimIndent()
+
+        val result = parser.parse(output)
+
+        assertEquals(1, result.size)
+        assertEquals("sub-domain.example.co.uk", result[0].domains[0].domain)
+    }
+
+    @Test
+    fun `parse should handle duplicate domain entries`() {
+        val output = """
+            com.example.app:
+              ID: 12345678
+              Signatures: [AA:BB]
+              Domain verification state:
+                example.com: verified
+                example.com: none
+        """.trimIndent()
+
+        val result = parser.parse(output)
+
+        assertEquals(1, result.size)
+        // Both entries should be preserved (real ADB output could have this)
+        assertEquals(2, result[0].domains.size)
+    }
+
+    @Test
+    fun `parse should skip package with no domains`() {
+        val output = """
+            com.example.app:
+              ID: 12345678
+              Signatures: [AA:BB]
+              Domain verification state:
+        """.trimIndent()
+
+        val result = parser.parse(output)
+
+        assertTrue(result.isEmpty(), "Package with no domains should be skipped")
+    }
+
+    @Test
+    fun `parse should handle error closed response`() {
+        val result = parser.parse("error: closed")
+        assertTrue(result.isEmpty(), "ADB error:closed should produce empty list")
+    }
+
+    @Test
+    fun `parse should handle all verification state values`() {
+        val output = """
+            com.example.app:
+              ID: 12345678
+              Signatures: [AA:BB]
+              Domain verification state:
+                a.example.com: verified
+                b.example.com: none
+                c.example.com: legacy_failure
+                d.example.com: restored
+        """.trimIndent()
+
+        val result = parser.parse(output)
+
+        assertEquals(1, result.size)
+        assertEquals(4, result[0].domains.size)
+        assertEquals(VerificationState.VERIFIED, result[0].domains[0].verificationState)
+        assertEquals(VerificationState.UNVERIFIED, result[0].domains[1].verificationState)
+        assertEquals(VerificationState.LEGACY_FAILURE, result[0].domains[2].verificationState)
+        assertEquals(VerificationState.UNKNOWN, result[0].domains[3].verificationState)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/com/manjee/linkops/domain/usecase/diagnostics/AnalyzeVerificationUseCaseTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/manjee/linkops/domain/usecase/diagnostics/AnalyzeVerificationUseCaseTest.kt
@@ -1,0 +1,146 @@
+package com.manjee.linkops.domain.usecase.diagnostics
+
+import com.manjee.linkops.domain.model.*
+import com.manjee.linkops.domain.repository.VerificationDiagnosticsRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class AnalyzeVerificationUseCaseTest {
+
+    @Test
+    fun `invoke should return diagnostics on success`() = runTest {
+        val expected = VerificationDiagnostics(
+            packageName = "com.example.app",
+            deviceSerial = "emulator-5554",
+            domainResults = listOf(
+                DomainDiagnosticResult(
+                    domain = "example.com",
+                    verificationState = VerificationState.VERIFIED,
+                    fingerprintComparison = FingerprintComparisonResult.Match,
+                    assetLinksStatus = AssetLinksStatus.VALID,
+                    failureReasons = emptyList(),
+                    suggestions = emptyList()
+                )
+            ),
+            localFingerprint = "AA:BB:CC:DD"
+        )
+
+        val repository = FakeVerificationDiagnosticsRepository(
+            result = Result.success(expected)
+        )
+        val useCase = AnalyzeVerificationUseCase(repository)
+
+        val result = useCase("emulator-5554", "com.example.app")
+
+        assertTrue(result.isSuccess)
+        val diagnostics = result.getOrNull()
+        assertNotNull(diagnostics)
+        assertEquals("com.example.app", diagnostics.packageName)
+        assertEquals("emulator-5554", diagnostics.deviceSerial)
+        assertEquals(1, diagnostics.domainResults.size)
+        assertEquals("AA:BB:CC:DD", diagnostics.localFingerprint)
+    }
+
+    @Test
+    fun `invoke should return failure when repository fails`() = runTest {
+        val error = RuntimeException("Device not found")
+        val repository = FakeVerificationDiagnosticsRepository(
+            result = Result.failure(error)
+        )
+        val useCase = AnalyzeVerificationUseCase(repository)
+
+        val result = useCase("emulator-5554", "com.example.app")
+
+        assertTrue(result.isFailure)
+        assertEquals("Device not found", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `invoke should pass correct parameters to repository`() = runTest {
+        val repository = FakeVerificationDiagnosticsRepository(
+            result = Result.success(
+                VerificationDiagnostics(
+                    packageName = "com.test.app",
+                    deviceSerial = "device-123",
+                    domainResults = emptyList(),
+                    localFingerprint = null
+                )
+            )
+        )
+        val useCase = AnalyzeVerificationUseCase(repository)
+
+        useCase("device-123", "com.test.app")
+
+        assertEquals("device-123", repository.lastDeviceSerial)
+        assertEquals("com.test.app", repository.lastPackageName)
+    }
+
+    @Test
+    fun `invoke should return diagnostics with multiple domain results`() = runTest {
+        val expected = VerificationDiagnostics(
+            packageName = "com.example.app",
+            deviceSerial = "device-1",
+            domainResults = listOf(
+                DomainDiagnosticResult(
+                    domain = "example.com",
+                    verificationState = VerificationState.VERIFIED,
+                    fingerprintComparison = FingerprintComparisonResult.Match,
+                    assetLinksStatus = AssetLinksStatus.VALID,
+                    failureReasons = emptyList(),
+                    suggestions = emptyList()
+                ),
+                DomainDiagnosticResult(
+                    domain = "test.example.com",
+                    verificationState = VerificationState.UNVERIFIED,
+                    fingerprintComparison = FingerprintComparisonResult.Mismatch(
+                        localFingerprint = "AA:BB",
+                        remoteFingerprints = listOf("CC:DD")
+                    ),
+                    assetLinksStatus = AssetLinksStatus.VALID,
+                    failureReasons = listOf(FailureReason.FINGERPRINT_MISMATCH),
+                    suggestions = listOf("Update fingerprint")
+                )
+            ),
+            localFingerprint = "AA:BB"
+        )
+
+        val repository = FakeVerificationDiagnosticsRepository(
+            result = Result.success(expected)
+        )
+        val useCase = AnalyzeVerificationUseCase(repository)
+
+        val result = useCase("device-1", "com.example.app")
+
+        assertTrue(result.isSuccess)
+        val diagnostics = result.getOrNull()!!
+        assertEquals(2, diagnostics.totalDomains)
+        assertEquals(1, diagnostics.verifiedDomains)
+        assertEquals(1, diagnostics.failedDomains)
+        assertTrue(diagnostics.hasIssues)
+    }
+}
+
+/**
+ * Fake implementation of VerificationDiagnosticsRepository for testing
+ */
+class FakeVerificationDiagnosticsRepository(
+    private val result: Result<VerificationDiagnostics>
+) : VerificationDiagnosticsRepository {
+
+    var lastDeviceSerial: String? = null
+        private set
+    var lastPackageName: String? = null
+        private set
+
+    override suspend fun analyzeVerification(
+        deviceSerial: String,
+        packageName: String
+    ): Result<VerificationDiagnostics> {
+        lastDeviceSerial = deviceSerial
+        lastPackageName = packageName
+        return result
+    }
+}


### PR DESCRIPTION
## Summary

- Add deep verification analysis for Android App Links with per-domain status tracking, certificate fingerprint comparison against `assetlinks.json`, and root cause analysis with actionable fix suggestions
- Update `GetAppLinksParser` to extract SHA256 signatures from `pm get-app-links` output (Android 12+)
- New "Deep Dive" screen in sidebar navigation for selecting device + package and running analysis

## Changes

### Domain Layer
- `VerificationDiagnostics` model with `DomainDiagnosticResult`, `FingerprintComparisonResult`, `AssetLinksStatus`, `FailureReason`
- `VerificationDiagnosticsRepository` interface
- `AnalyzeVerificationUseCase`

### Data Layer
- `CertificateFingerprintComparator` - compares local APK fingerprint vs remote assetlinks.json fingerprints (case-insensitive, colon-tolerant)
- `VerificationFailureAnalyzer` - identifies failure root causes (missing assetlinks.json, fingerprint mismatch, redirect, etc.) with actionable suggestions
- `VerificationDiagnosticsRepositoryImpl` - orchestrates ADB queries, concurrent assetlinks.json fetching, and analysis
- Updated `GetAppLinksParser` to extract `Signatures:` field and populate `DomainVerification.fingerprint`

### UI Layer
- `VerificationDeepDiveViewModel` with `VerificationDeepDiveUiState`
- `VerificationDeepDiveScreen` with device selector, package input, summary card, and per-domain diagnostics cards
- Navigation: new `Screen.VerificationDeepDive` + sidebar "Deep Dive" tab

### Tests (47 new tests)
- `GetAppLinksParserTest` (17 tests) - fingerprint extraction, edge cases, all verification states
- `CertificateFingerprintComparatorTest` (13 tests) - match, mismatch, normalization, missing data scenarios
- `VerificationFailureAnalyzerTest` (13 tests) - all failure reasons, multiple simultaneous failures, suggestions
- `AnalyzeVerificationUseCaseTest` (4 tests) - success/failure paths with FakeRepository

## Test plan
- [x] All 47 new tests pass
- [x] All existing tests pass (regression)
- [x] Compilation passes without errors
- [x] Manual: Connect device, select package with app links, verify domain status cards show correctly
- [x] Manual: Test with package that has fingerprint mismatch to verify root cause analysis
- [x] Manual: Test with domain returning 404 for assetlinks.json

Closes #11